### PR TITLE
Rehook

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.9
+current_version = 0.3.10
 commit = False
 tag = False
 tag_name = v{new_version}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 CHANGE LOG
 ==========
 
+0.3.10 - 2019.02.05
+-------------------
+* [ENHANCEMENT] Perform work in '.pyppyn' directory.
+
 0.3.9 - 2019.01.29
 ------------------
 * [ENHANCEMENT] Minor cleanup.

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ flake8 = "==3.6.0"
 pylint = "==2.2.2"
 
 [packages]
-distlib = "==0.2.8"
 setuptools = "==40.6.3"
 click = "==7.0"
 wheel = "==0.32.3"

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ flake8 = "==3.6.0"
 pylint = "==2.2.2"
 
 [packages]
-setuptools = "==40.6.3"
+setuptools = "==40.7.3"
 click = "==7.0"
 wheel = "==0.32.3"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9cdd49fbdefdbcbee077866431181ba3738b9d350b0887ad387c47191b6922a4"
+            "sha256": "9d179b6d7640234a1fc2f8c51f42c00ac17592b08973e657c7a07610045bfb7f"
         },
         "pipfile-spec": 6,
         "requires": {},

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b752d5335770e8fe294daab7f79b9834e932c8cda2ef1a9885392c34067a6591"
+            "sha256": "9cdd49fbdefdbcbee077866431181ba3738b9d350b0887ad387c47191b6922a4"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -22,13 +22,6 @@
             "index": "pypi",
             "version": "==7.0"
         },
-        "distlib": {
-            "hashes": [
-                "sha256:57977cd7d9ea27986ec62f425630e4ddb42efe651ff80bc58ed8dbc3c7c21f19"
-            ],
-            "index": "pypi",
-            "version": "==0.2.8"
-        },
         "wheel": {
             "hashes": [
                 "sha256:029703bf514e16c8271c3821806a1c171220cc5bdd325cbf4e7da1e056a01db6",
@@ -48,10 +41,10 @@
         },
         "atomicwrites": {
             "hashes": [
-                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
-                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
             ],
-            "version": "==1.2.1"
+            "version": "==1.3.0"
         },
         "attrs": {
             "hashes": [

--- a/pyppyn/__init__.py
+++ b/pyppyn/__init__.py
@@ -37,7 +37,7 @@ import sys
 import uuid
 import zipfile
 
-__version__ = "0.3.9"
+__version__ = "0.3.10"
 
 __EXITOKAY__ = 0
 FILE_DIR = ".pyppyn"

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 
 [options]
 install_requires = 
-    setuptools==40.7.2
+    setuptools==40.7.3
     click==7.0
     wheel==0.32.3
 packages = pyppyn

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,7 @@ classifiers =
 
 [options]
 install_requires = 
-    distlib==0.2.8
-    setuptools==40.6.3
+    setuptools==40.7.2
     click==7.0
     wheel==0.32.3
 packages = pyppyn


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Remove distlib from dependencies (dependency of dependency)
* Update setuptools version
* Perform pyppyn work in `.pyppyn` directory

Output from Pytest:

```console
$ pytest
========================================== test session starts ==========================================
platform darwin -- Python 3.7.2, pytest-4.2.0, py-1.7.0, pluggy-0.8.1
rootdir: /Users/dirkavery/dev/pyppyn, inifile: setup.cfg
collected 10 items                                                                                      

tests/test_pyppyn.py ..........                                                                   [100%]

======================================= 10 passed in 8.91 seconds =======================================
```
