### PR TITLE
Fix issue with virtualenv, py3.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,10 @@ jobs:
       dist: xenial
     - stage: test
       os: windows
-      language: sh
-      python: 3.7
+      language: shell
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install:
-        - choco install python3
-        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+        - choco install python --version 3.7.3
         - python -m pip install virtualenv
         - virtualenv $HOME/venv
         - source $HOME/venv/Scripts/activate
@@ -99,7 +98,7 @@ jobs:
         - RELEASE_BODY="* [$THIS_REPO v$RELEASE_VERSION CHANGELOG](https://github.com/$OWNER/$THIS_REPO/compare/$PRIOR_VERSION...$RELEASE_VERSION)"
       install: skip
       script:
-        - echo RELEASE_BODY=$RELEASE_BODY 
+        - echo RELEASE_BODY=$RELEASE_BODY
       deploy:
         - provider: releases
           api_key:


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* Pin python version to 3.7.3 in travis tests to avoid virtualenv, py3.7.4 infinite loop issue
