### PR TITLE
Unpin python, add CI requirements file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ jobs:
       language: shell
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install:
-        - choco install python --version 3.7.3
-        - python -m pip install virtualenv
+        - choco install python
+        - python -m pip install -r requirements/ci.txt
         - virtualenv $HOME/venv
         - source $HOME/venv/Scripts/activate
       install:
@@ -61,7 +61,7 @@ jobs:
       python: 3.7
       # Perform the manual steps on osx to install python3 and activate venv
       before_install:
-        - python3 -m pip install virtualenv
+        - python -m pip install -r requirements/ci.txt
         - virtualenv $HOME/venv -p python3
         - source $HOME/venv/bin/activate
       cache:

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,0 +1,1 @@
+virtualenv==16.6.2


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

Changes proposed in this pull request:

* For Windows Travis CI testing, remove the python 3.7.3 pin and pin virtualenv to the current version for maintenance by dependabot.
