### PR TITLE
Parse Extra requires

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
-current_version = 0.3.67
-commit = False
+current_version = 0.4.0
+commit = True
 tag = False
 tag_name = v{new_version}
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGE LOG
 ==========
 
+0.4.0 - 2021.08.02
+-------------------
+* [FEATURE] Add option to include/exclude extras_require from required packages,
+  using `get_required(include_extras_require=False)`.
+
 0.3.17 - 2020.02.27
 -------------------
 * [FIX] Remove standard packages from setup.cfg install requires.

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ This is a sample usage of Pyppyn from a Python script.
     # Load config, install dependencies and import a module from the package
     p.process_config()
 
-    print("Package requires:", p.get_required())
+    print("Package requires:", p.get_required(include_extras_require=False))
 
 Contribute
 ==========

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   - script: |
       call $(venvDirectory)/Scripts/activate.bat
       python -m pip install --editable .
-    displayName: install gravitybee
+    displayName: install pyppyn
   - script: |
       call $(venvDirectory)/Scripts/activate.bat
       python -m pip list

--- a/pyppyn/__init__.py
+++ b/pyppyn/__init__.py
@@ -145,7 +145,7 @@ class ConfigRep:
         self.python_version = sys.version_info[0] + (sys.version_info[1] / 10)
 
         # requirements
-        self.reqs = {"os": [], "other": [], "base": [], "python": [], "unparsed": []}
+        self.reqs = {"os": [], "other": [], "base": [], "python": [], "unparsed": [], "extra": []}
 
         # suffix for renaming build/dist directories
         self._rename_end = None
@@ -361,6 +361,8 @@ class ConfigRep:
             ):
                 self.reqs["python"].append(package)
 
+        elif marker_parts[0] == "extra":
+            self.reqs["extra"].append(package)
         else:
             self.reqs["unparsed"].append(package)
 
@@ -433,20 +435,30 @@ class ConfigRep:
 
         return self._status["did_load"] == self._status["should_load"]
 
-    def get_required(self):
-        """Return required packages based on configuration."""
+    def get_required(self, include_extra_require=False):
+        """Return required packages based on configuration.
+
+        Args:
+            include_extra_require: Boolean. If True, include
+                packages tagged as "extra" in return.
+        """
         if (
             self._status["state"] != ConfigRep.STATE_LOAD
             and self._status["state"] != ConfigRep.STATE_INSTALLED
         ):
             self.load_config()
 
-        return (
+        required = (
             self.reqs["base"]
             + self.reqs["os"]
             + self.reqs["python"]
             + self.reqs["unparsed"]
         )
+
+        if include_extra_require:
+            required = required + self.reqs["extra"]
+
+        return required
 
     def get_config_attr(self, key, element=0):
         """Return value associated with a key in the configuration.

--- a/pyppyn/__init__.py
+++ b/pyppyn/__init__.py
@@ -145,7 +145,14 @@ class ConfigRep:
         self.python_version = sys.version_info[0] + (sys.version_info[1] / 10)
 
         # requirements
-        self.reqs = {"os": [], "other": [], "base": [], "python": [], "unparsed": [], "extra": []}
+        self.reqs = {
+            "os": [],
+            "other": [],
+            "base": [],
+            "python": [],
+            "unparsed": [],
+            "extra": [],
+        }
 
         # suffix for renaming build/dist directories
         self._rename_end = None

--- a/pyppyn/__init__.py
+++ b/pyppyn/__init__.py
@@ -442,11 +442,11 @@ class ConfigRep:
 
         return self._status["did_load"] == self._status["should_load"]
 
-    def get_required(self, include_extra_require=False):
+    def get_required(self, include_extras_require=False):
         """Return required packages based on configuration.
 
         Args:
-            include_extra_require: Boolean. If True, include
+            include_extras_require: Boolean. If True, include
                 packages tagged as "extra" in return.
         """
         if (
@@ -462,7 +462,7 @@ class ConfigRep:
             + self.reqs["unparsed"]
         )
 
-        if include_extra_require:
+        if include_extras_require:
             required = required + self.reqs["extra"]
 
         return required

--- a/pyppyn/__init__.py
+++ b/pyppyn/__init__.py
@@ -43,7 +43,7 @@ import sys
 import uuid
 import zipfile
 
-__version__ = "0.3.67"
+__version__ = "0.4.0"
 
 __EXITOKAY__ = 0
 FILE_DIR = ".pyppyn"

--- a/pyppyn/__init__.py
+++ b/pyppyn/__init__.py
@@ -442,11 +442,11 @@ class ConfigRep:
 
         return self._status["did_load"] == self._status["should_load"]
 
-    def get_required(self, include_extras_require=False):
+    def get_required(self, include_extras_require=True):
         """Return required packages based on configuration.
 
         Args:
-            include_extras_require: Boolean. If True, include
+            include_extras_require: Boolean. If False, skip
                 packages tagged as "extra" in return.
         """
         if (

--- a/tests/minipippy/setup.cfg
+++ b/tests/minipippy/setup.cfg
@@ -79,3 +79,11 @@ addopts =
     --doctest-modules
     --doctest-glob=\*.md
     --tb=short
+
+[options.extras_require]
+test =
+    pytest
+check =
+    flake8
+docs =
+    sphinx

--- a/tests/test_pyppyn.py
+++ b/tests/test_pyppyn.py
@@ -77,16 +77,29 @@ def test_get_required(configrep):
             ["backoff", "click", "six", "pyyaml"]
         )
 
+
 def test_get_required_including_extras(configrep):
-    """Test getting list of requirements, including extra packages (tagged with "test", "check", "docs")."""
+    """Test getting list of requirements, including extra packages
+       (such as those marked with "test", "check", "docs")."""
     if platform.system().lower() == "windows":
         assert set(configrep.get_required(include_extra_require=True)) == set(
-            ["backoff", "click", "pyyaml", "defusedxml", "pypiwin32", "six", "pytest", "flake8", "sphinx"]
+            [
+                "backoff",
+                "click",
+                "pyyaml",
+                "defusedxml",
+                "pypiwin32",
+                "six",
+                "pytest",
+                "flake8",
+                "sphinx",
+            ]
         )
     else:
         assert set(configrep.get_required(include_extra_require=True)) == set(
             ["backoff", "click", "six", "pyyaml", "pytest", "flake8", "sphinx"]
         )
+
 
 def test_install_package():
     """Test the class method."""

--- a/tests/test_pyppyn.py
+++ b/tests/test_pyppyn.py
@@ -80,7 +80,7 @@ def test_get_required(configrep):
 
 def test_get_required_with_extras(configrep):
     """Test getting list of requirements, including extra packages
-       (such as those marked with "test", "check", "docs")."""
+    (such as those marked with "test", "check", "docs")."""
     if platform.system().lower() == "windows":
         assert set(configrep.get_required(include_extra_require=True)) == set(
             [

--- a/tests/test_pyppyn.py
+++ b/tests/test_pyppyn.py
@@ -67,22 +67,10 @@ def test_process_config(configrep):
 
 
 def test_get_required(configrep):
-    """Test getting list of requirements."""
-    if platform.system().lower() == "windows":
-        assert set(configrep.get_required()) == set(
-            ["backoff", "click", "pyyaml", "defusedxml", "pypiwin32", "six"]
-        )
-    else:
-        assert set(configrep.get_required()) == set(
-            ["backoff", "click", "six", "pyyaml"]
-        )
-
-
-def test_get_required_with_extras(configrep):
     """Test getting list of requirements, including extra packages
     (such as those marked with "test", "check", "docs")."""
     if platform.system().lower() == "windows":
-        assert set(configrep.get_required(include_extras_require=True)) == set(
+        assert set(configrep.get_required()) == set(
             [
                 "backoff",
                 "click",
@@ -96,8 +84,20 @@ def test_get_required_with_extras(configrep):
             ]
         )
     else:
-        assert set(configrep.get_required(include_extras_require=True)) == set(
+        assert set(configrep.get_required()) == set(
             ["backoff", "click", "six", "pyyaml", "pytest", "flake8", "sphinx"]
+        )
+
+
+def test_get_required_no_extras(configrep):
+    """Test getting list of requirements."""
+    if platform.system().lower() == "windows":
+        assert set(configrep.get_required(include_extras_require=False)) == set(
+            ["backoff", "click", "pyyaml", "defusedxml", "pypiwin32", "six"]
+        )
+    else:
+        assert set(configrep.get_required(include_extras_require=False)) == set(
+            ["backoff", "click", "six", "pyyaml"]
         )
 
 

--- a/tests/test_pyppyn.py
+++ b/tests/test_pyppyn.py
@@ -77,6 +77,16 @@ def test_get_required(configrep):
             ["backoff", "click", "six", "pyyaml"]
         )
 
+def test_get_required_including_extras(configrep):
+    """Test getting list of requirements, including extra packages (tagged with "test", "check", "docs")."""
+    if platform.system().lower() == "windows":
+        assert set(configrep.get_required(include_extra_require=True)) == set(
+            ["backoff", "click", "pyyaml", "defusedxml", "pypiwin32", "six", "pytest", "flake8", "sphinx"]
+        )
+    else:
+        assert set(configrep.get_required(include_extra_require=True)) == set(
+            ["backoff", "click", "six", "pyyaml", "pytest", "flake8", "sphinx"]
+        )
 
 def test_install_package():
     """Test the class method."""

--- a/tests/test_pyppyn.py
+++ b/tests/test_pyppyn.py
@@ -82,7 +82,7 @@ def test_get_required_with_extras(configrep):
     """Test getting list of requirements, including extra packages
     (such as those marked with "test", "check", "docs")."""
     if platform.system().lower() == "windows":
-        assert set(configrep.get_required(include_extra_require=True)) == set(
+        assert set(configrep.get_required(include_extras_require=True)) == set(
             [
                 "backoff",
                 "click",
@@ -96,7 +96,7 @@ def test_get_required_with_extras(configrep):
             ]
         )
     else:
-        assert set(configrep.get_required(include_extra_require=True)) == set(
+        assert set(configrep.get_required(include_extras_require=True)) == set(
             ["backoff", "click", "six", "pyyaml", "pytest", "flake8", "sphinx"]
         )
 

--- a/tests/test_pyppyn.py
+++ b/tests/test_pyppyn.py
@@ -78,7 +78,7 @@ def test_get_required(configrep):
         )
 
 
-def test_get_required_including_extras(configrep):
+def test_get_required_with_extras(configrep):
     """Test getting list of requirements, including extra packages
        (such as those marked with "test", "check", "docs")."""
     if platform.system().lower() == "windows":


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->
Fixes #303

Changes proposed in this pull request:

* Parse extra requires into new req category "extra"
* `get_required()` does not return "extra" packages by default, add parameter `include_extra_requires` to include these

Output from Pytest:

```
(venv) λ pytest
===================================================== test session starts ======================================================
platform win32 -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: C:\workspace\pypackaging\pyppyn, configfile: setup.cfg
collected 11 items

tests\test_pyppyn.py ...........                                                                                          [100%]

======================================================= warnings summary ======================================================= 
venv\lib\site-packages\_pytest\config\__init__.py:1183
  c:\workspace\pypackaging\pyppyn\venv\lib\site-packages\_pytest\config\__init__.py:1183: PytestDeprecationWarning: The --strict 
option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================ 11 passed, 1 warning in 23.33s ================================================ 
```
